### PR TITLE
WIP: Use exact alarm scheduling for API versions >= 19

### DIFF
--- a/Calendula/build.gradle
+++ b/Calendula/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.3'
     }
 }
 apply plugin: 'com.android.application'
@@ -32,13 +32,13 @@ def getDate() {
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 23
+    buildToolsVersion "24.0.2"
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 21
-        versionCode 24
-        versionName "2.3.8"
+        targetSdkVersion 23
+        versionCode 25
+        versionName "2.3.9"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/Calendula/src/main/java/es/usc/citius/servando/calendula/CalendulaApp.java
+++ b/Calendula/src/main/java/es/usc/citius/servando/calendula/CalendulaApp.java
@@ -46,6 +46,8 @@ public class CalendulaApp extends Application {
     public static final String INTENT_EXTRA_SCHEDULE_TIME = "schedule_time";
     public static final String INTENT_EXTRA_DELAY_ROUTINE_ID = "delay_routine_id";
     public static final String INTENT_EXTRA_DELAY_SCHEDULE_ID = "delay_schedule_id";
+    public static final String INTENT_EXTRA_REPEAT_MILLISEC = "repeat_millisec";
+
     // ACTIONS
     public static final int ACTION_ROUTINE_TIME = 1;
     public static final int ACTION_DAILY_ALARM = 2;

--- a/Calendula/src/main/java/es/usc/citius/servando/calendula/scheduling/AlarmScheduler.java
+++ b/Calendula/src/main/java/es/usc/citius/servando/calendula/scheduling/AlarmScheduler.java
@@ -39,7 +39,7 @@ public class AlarmScheduler {
     private AlarmScheduler() {
     }
 
-    public static PendingIntent alarmPendingIntent(Context ctx, Routine routine) {
+    public static PendingIntent alarmPendingIntent(Context ctx, Routine routine, long intervalMillisec) {
         // intent our receiver will receive
         Intent intent = new Intent(ctx, AlarmReceiver.class);
         // indicate thar is for a routine
@@ -47,6 +47,11 @@ public class AlarmScheduler {
         // pass the routine id (hash code)
         //Log.d(TAG, "Put extra " + CalendulaApp.INTENT_EXTRA_ROUTINE_ID + ": " + routine.getId());
         intent.putExtra(CalendulaApp.INTENT_EXTRA_ROUTINE_ID, routine.getId());
+
+
+        // store interval for which to reschedule alarm on receive
+        intent.putExtra(CalendulaApp.INTENT_EXTRA_REPEAT_MILLISEC, intervalMillisec);
+
         // create pending intent
         int intent_id = routine.getId().hashCode();
         return PendingIntent.getBroadcast(ctx, intent_id, intent, PendingIntent.FLAG_UPDATE_CURRENT);
@@ -114,12 +119,23 @@ public class AlarmScheduler {
 
             Log.d(TAG, "Updating routine alarm [" + routine.name() + "]");
             // get routine pending intent
-            PendingIntent routinePendingIntent = alarmPendingIntent(ctx, routine);
+            PendingIntent routinePendingIntent = alarmPendingIntent(ctx, routine, AlarmManager.INTERVAL_DAY);
             // Get the AlarmManager service
             AlarmManager alarmManager = (AlarmManager) ctx.getSystemService(Context.ALARM_SERVICE);
             // set the routine alarm, with repetition every day
             if (alarmManager != null) {
-                alarmManager.setRepeating(AlarmManager.RTC_WAKEUP, routine.time().toDateTimeToday().getMillis(), AlarmManager.INTERVAL_DAY, routinePendingIntent);
+            // alarmManager.setRepeating(AlarmManager.RTC_WAKEUP, routine.time().toDateTimeToday().getMillis(), AlarmManager.INTERVAL_DAY, routinePendingIntent);
+                if (Build.VERSION.SDK_INT >= 23)
+                {
+                    alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, routine.time().toDateTimeToday().getMillis(), routinePendingIntent);
+                } else if (Build.VERSION.SDK_INT >= 19 )
+                {
+                    alarmManager.setExact(AlarmManager.RTC_WAKEUP, routine.time().toDateTimeToday().getMillis(), routinePendingIntent);
+                } else
+                {
+                    alarmManager.set(AlarmManager.RTC_WAKEUP, routine.time().toDateTimeToday().getMillis(), routinePendingIntent);
+                }
+
                 Duration timeToAlarm = new Duration(LocalTime.now().toDateTimeToday(), routine.time().toDateTimeToday());
                 Log.d(TAG, "Alarm scheduled to " + timeToAlarm.getMillis() + " millis");
             }
@@ -165,7 +181,7 @@ public class AlarmScheduler {
     private void cancelAlarm(Routine routine, Context ctx)
     {
         // get routine pending intent
-        PendingIntent routinePendingIntent = alarmPendingIntent(ctx, routine);
+        PendingIntent routinePendingIntent = alarmPendingIntent(ctx, routine, AlarmManager.INTERVAL_DAY);
         // Get the AlarmManager service
         AlarmManager alarmManager = (AlarmManager) ctx.getSystemService(Context.ALARM_SERVICE);
         if (alarmManager != null) {

--- a/Calendula/src/main/java/es/usc/citius/servando/calendula/scheduling/AlarmScheduler.java
+++ b/Calendula/src/main/java/es/usc/citius/servando/calendula/scheduling/AlarmScheduler.java
@@ -47,11 +47,10 @@ public class AlarmScheduler {
         // pass the routine id (hash code)
         //Log.d(TAG, "Put extra " + CalendulaApp.INTENT_EXTRA_ROUTINE_ID + ": " + routine.getId());
         intent.putExtra(CalendulaApp.INTENT_EXTRA_ROUTINE_ID, routine.getId());
-
-
-        // store interval for which to reschedule alarm on receive
-        intent.putExtra(CalendulaApp.INTENT_EXTRA_REPEAT_MILLISEC, intervalMillisec);
-
+        if (intervalMillisec != 0) {
+            // store interval for which to reschedule alarm on receive
+            intent.putExtra(CalendulaApp.INTENT_EXTRA_REPEAT_MILLISEC, intervalMillisec);
+        }
         // create pending intent
         int intent_id = routine.getId().hashCode();
         return PendingIntent.getBroadcast(ctx, intent_id, intent, PendingIntent.FLAG_UPDATE_CURRENT);

--- a/Calendula/src/main/java/es/usc/citius/servando/calendula/scheduling/AlarmScheduler.java
+++ b/Calendula/src/main/java/es/usc/citius/servando/calendula/scheduling/AlarmScheduler.java
@@ -5,6 +5,7 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
@@ -143,8 +144,21 @@ public class AlarmScheduler {
         {
             Log.d(TAG, " Time: " + time.getMillis() + ", " + ((time.getMillis() - DateTime.now()
                 .getMillis()) / 1000 / 60) + " min]");
-            alarmManager.set(AlarmManager.RTC_WAKEUP, time.getMillis(),
-                hourlySchedulePendingIntent);
+
+            if (Build.VERSION.SDK_INT >= 23)
+            {
+                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, time.getMillis(),
+                        hourlySchedulePendingIntent);
+            } else if (Build.VERSION.SDK_INT >= 19 )
+            {
+                alarmManager.setExact(AlarmManager.RTC_WAKEUP, time.getMillis(),
+                        hourlySchedulePendingIntent);
+            } else
+            {
+                alarmManager.set(AlarmManager.RTC_WAKEUP, time.getMillis(),
+                        hourlySchedulePendingIntent);
+            }
+
         }
     }
 
@@ -178,7 +192,16 @@ public class AlarmScheduler {
             AlarmManager alarmManager = (AlarmManager) ctx.getSystemService(Context.ALARM_SERVICE);
             // set the routine alarm, with repetition every day
             if (alarmManager != null) {
-                alarmManager.set(AlarmManager.RTC_WAKEUP, DateTime.now().getMillis() + millis, routinePendingIntent);
+                if (Build.VERSION.SDK_INT >= 23)
+                {
+                    alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, DateTime.now().getMillis() + millis, routinePendingIntent);
+                } else if (Build.VERSION.SDK_INT >= 19 )
+                {
+                    alarmManager.setExact(AlarmManager.RTC_WAKEUP, DateTime.now().getMillis() + millis, routinePendingIntent);
+                } else
+                {
+                    alarmManager.set(AlarmManager.RTC_WAKEUP, DateTime.now().getMillis() + millis, routinePendingIntent);
+                }
                 Log.d(TAG, "Alarm delayed " + millis + " millis");
             }
         }
@@ -198,8 +221,16 @@ public class AlarmScheduler {
         AlarmManager alarmManager = (AlarmManager) ctx.getSystemService(Context.ALARM_SERVICE);
         // set the routine alarm, with repetition every day
         if (alarmManager != null) {
-            alarmManager.set(AlarmManager.RTC_WAKEUP, DateTime.now().getMillis() + millis,
-                    routinePendingIntent);
+            if (Build.VERSION.SDK_INT >= 23)
+            {
+                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, DateTime.now().getMillis() + millis, routinePendingIntent);
+            } else if (Build.VERSION.SDK_INT >= 19 )
+            {
+                alarmManager.setExact(AlarmManager.RTC_WAKEUP, DateTime.now().getMillis() + millis, routinePendingIntent);
+            } else
+            {
+                alarmManager.set(AlarmManager.RTC_WAKEUP, DateTime.now().getMillis() + millis, routinePendingIntent);
+            }
             Log.d(TAG, "Alarm delayed " + millis + " millis");
         }
     }

--- a/Calendula/src/main/java/es/usc/citius/servando/calendula/scheduling/PickupReminderMgr.java
+++ b/Calendula/src/main/java/es/usc/citius/servando/calendula/scheduling/PickupReminderMgr.java
@@ -4,6 +4,7 @@ import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.util.Log;
 
 import org.joda.time.DateTime;
@@ -45,7 +46,16 @@ public class PickupReminderMgr {
         // Get the AlarmManager service
         AlarmManager alarmManager = (AlarmManager) ctx.getSystemService(Context.ALARM_SERVICE);
         if (alarmManager != null) {
-            alarmManager.set(AlarmManager.RTC_WAKEUP, d.getMillis(), calendarReminderPendingIntent);
+            if (Build.VERSION.SDK_INT >= 23)
+            {
+                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, d.getMillis(), calendarReminderPendingIntent);
+            } else if (Build.VERSION.SDK_INT >= 19 )
+            {
+                alarmManager.setExact(AlarmManager.RTC_WAKEUP, d.getMillis(), calendarReminderPendingIntent);
+            } else
+            {
+                alarmManager.set(AlarmManager.RTC_WAKEUP, d.getMillis(), calendarReminderPendingIntent);
+            }
             Log.d(TAG, "Pickup check alarm scheduled!");
         }
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Mar 30 11:02:34 CEST 2015
+#Fri Aug 26 18:20:43 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/libraries/BetterPickersLib/build.gradle
+++ b/libraries/BetterPickersLib/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.3'
     }
 }
 apply plugin: 'com.android.library'

--- a/libraries/ExpandableListview/build.gradle
+++ b/libraries/ExpandableListview/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.3'
     }
 }
 apply plugin: 'com.android.library'


### PR DESCRIPTION
Fixes #52 

Tested for two days on my device (CM13, Android 6.0.1), alarm times are exact with these changes. No errors were observed, but I could not yet test on older devices. Also, no significant battery usage increase happened.
Looking forward to your testing and feedback.