### PR TITLE
gitlab-ci: add generated DB file as an artifact

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,4 +25,5 @@ build:
       - Calendula/build/reports/tests/
       - Calendula/build/test-results/
       - Calendula/build/reports/jacoco/
+      - generated/
     expire_in: 1 week


### PR DESCRIPTION
Since we're generating the DB as a test, we may as well make it
available as an artifact for easier examining.