### PR TITLE
Update Kotlin to 1.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     ext {
         gradle_plugin_version = '3.2.1'
-        kotlin_version = '1.2.71'
+        kotlin_version = '1.3.0'
         jacoco_plugin_version = '0.12.0'
         libVersions = [
                 android: [


### PR DESCRIPTION
Kotlin 1.3 is now stable, so update to that version.

This, however:
- Needs careful review to verify everything works as expected
- Needs an upgrade of the AS plugin that isn't offered in the usual way (have to go through Settings).

Release notes: https://blog.jetbrains.com/kotlin/2018/10/kotlin-1-3/
